### PR TITLE
More memory savings

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -338,19 +338,21 @@ module Datadog
       :DOUBLE_COLON, :UNDERSCORE
 
     def escape_event_content(msg)
-      msg.gsub NEW_LINE, ESC_NEW_LINE
+      msg.gsub!(NEW_LINE, ESC_NEW_LINE) || msg
     end
 
     def escape_tag_content(tag)
-      remove_pipes(tag).gsub COMMA, BLANK
+      tag = remove_pipes(tag)
+      tag.gsub!(COMMA, BLANK) || tag
     end
 
     def remove_pipes(msg)
-      msg.gsub PIPE, BLANK
+      msg.gsub!(PIPE, BLANK) || msg
     end
 
     def escape_service_check_message(msg)
-      escape_event_content(msg).gsub('m:'.freeze, 'm\:'.freeze)
+      msg = escape_event_content(msg)
+      msg.gsub!('m:'.freeze, 'm\:'.freeze) || msg
     end
 
     def time_since(stat, start, opts)
@@ -361,7 +363,10 @@ module Datadog
       sample_rate = opts[:sample_rate] || 1
       if sample_rate == 1 or rand < sample_rate
         # Replace Ruby module scoping with '.' and reserved chars (: | @) with underscores.
-        stat = stat.to_s.gsub(DOUBLE_COLON, DOT).tr(':|@'.freeze, UNDERSCORE)
+        stat = stat.to_s
+        stat.gsub!(DOUBLE_COLON, DOT)
+        stat.tr!(':|@'.freeze, UNDERSCORE)
+
         rate = "|@#{sample_rate}" unless sample_rate == 1
         ts = (tags || []) + (opts[:tags] || []).map {|tag| escape_tag_content(tag)}
         tags = "|##{ts.join(COMMA)}" unless ts.empty?

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -244,22 +244,35 @@ module Datadog
     end
 
     def format_service_check(name, status, opts={})
-      sc_string = "_sc|#{name}|#{status}"
+      sc_string = ''
+      sc_string << '_sc'.freeze
+      sc_string << PIPE
+      sc_string << name
+      sc_string << PIPE
+      sc_string << status.to_s
 
       SC_OPT_KEYS.each do |key, shorthand_key|
         next unless opts[key]
 
         if key == :tags
           tags = opts[:tags].map {|tag| escape_tag_content(tag) }
-          tags = "#{tags.join(COMMA)}" unless tags.empty?
-          sc_string << "|##{tags}"
+          unless tags.empty?
+            sc_string << PIPE
+            sc_string << HASH_TAG
+            sc_string << tags.join(COMMA)
+          end
         elsif key == :message
           message = remove_pipes(opts[:message])
           escaped_message = escape_service_check_message(message)
-          sc_string << "|m:#{escaped_message}"
+          sc_string << PIPE
+          sc_string << 'm'.freeze
+          sc_string << COLON
+          sc_string << escaped_message
         else
           value = remove_pipes(opts[key])
-          sc_string << "|#{shorthand_key}#{value}"
+          sc_string << PIPE
+          sc_string << shorthand_key
+          sc_string << value
         end
       end
       return sc_string

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -46,6 +46,12 @@ module Datadog
     CRITICAL  = 2
     UNKNOWN   = 3
 
+    COUNTER_TYPE = 'c'.freeze
+    GAUGE_TYPE = 'g'.freeze
+    HISTOGRAM_TYPE = 'h'.freeze
+    TIMING_TYPE = 'ms'.freeze
+    SET_TYPE = 's'.freeze
+
     # A namespace to prepend to all statsd calls. Defaults to no namespace.
     attr_reader :namespace
 
@@ -141,7 +147,7 @@ module Datadog
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
     # @option opts [Array<String>] :tags An array of tags
     def count(stat, count, opts={})
-      send_stats stat, count, :c, opts
+      send_stats stat, count, COUNTER_TYPE, opts
     end
 
     # Sends an arbitary gauge value for the given stat to the statsd server.
@@ -158,7 +164,7 @@ module Datadog
     # @example Report the current user count:
     #   $statsd.gauge('user.count', User.count)
     def gauge(stat, value, opts={})
-      send_stats stat, value, :g, opts
+      send_stats stat, value, GAUGE_TYPE, opts
     end
 
     # Sends a value to be tracked as a histogram to the statsd server.
@@ -171,7 +177,7 @@ module Datadog
     # @example Report the current user count:
     #   $statsd.histogram('user.count', User.count)
     def histogram(stat, value, opts={})
-      send_stats stat, value, :h, opts
+      send_stats stat, value, HISTOGRAM_TYPE, opts
     end
 
     # Sends a timing (in ms) for the given stat to the statsd server. The
@@ -185,7 +191,7 @@ module Datadog
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
     # @option opts [Array<String>] :tags An array of tags
     def timing(stat, ms, opts={})
-      send_stats stat, ms, :ms, opts
+      send_stats stat, ms, TIMING_TYPE, opts
     end
 
     # Reports execution time of the provided block using {#timing}.
@@ -217,7 +223,7 @@ module Datadog
     # @example Record a unique visitory by id:
     #   $statsd.set('visitors.uniques', User.id)
     def set(stat, value, opts={})
-      send_stats stat, value, :s, opts
+      send_stats stat, value, SET_TYPE, opts
     end
 
 
@@ -362,15 +368,34 @@ module Datadog
     def send_stats(stat, delta, type, opts={})
       sample_rate = opts[:sample_rate] || 1
       if sample_rate == 1 or rand < sample_rate
+        full_stat = ""
+        full_stat << @prefix if @prefix
+
         # Replace Ruby module scoping with '.' and reserved chars (: | @) with underscores.
         stat = stat.to_s
         stat.gsub!(DOUBLE_COLON, DOT)
         stat.tr!(':|@'.freeze, UNDERSCORE)
 
-        rate = "|@#{sample_rate}" unless sample_rate == 1
-        ts = (tags || []) + (opts[:tags] || []).map {|tag| escape_tag_content(tag)}
-        tags = "|##{ts.join(COMMA)}" unless ts.empty?
-        send_stat "#{@prefix}#{stat}:#{delta}|#{type}#{rate}#{tags}"
+        full_stat << stat
+        full_stat << ':'.freeze
+        full_stat << delta.to_s
+        full_stat << PIPE
+        full_stat << type
+
+        unless sample_rate == 1
+          full_stat << PIPE
+          full_stat << '@'.freeze
+          full_stat << sample_rate.to_s
+        end
+
+        ts = tags.to_a + opts[:tags].to_a.map {|tag| escape_tag_content(tag)}
+        unless ts.empty?
+          full_stat << PIPE
+          full_stat << '#'.freeze
+          full_stat << ts.join(COMMA)
+        end
+
+        send_stat full_stat
       end
     end
 


### PR DESCRIPTION
## Context

I made a PR in to DD's version of the gem replacing the strings with frozen strings or symbols wherever possible (https://github.com/DataDog/dogstatsd-ruby/pull/37)

vmg gave it a 👀 and said

> I think the next step would be to switch over to bang methods and incremental string composition, like aroben did for our fork of statsd. :)

So, using https://github.com/github/statsd-ruby/pull/16 as inspiration, I took a stab at replacing the string modification methods with  their `!` equivalents and incrementally creating the strings being sent.
## This Change
- updates the `send_stats` method to incrementally generate the string instead of one big string interpolation
- updates the `format_event` method to incrementally generate the string
- updates the `format_service_check` method to incrementally generate the string
- update all of the `gsub`s to `gsub!` and update the `tr` to `tr!`

All of the tests are still passing! 💃 🎉 
